### PR TITLE
rename module to license-reporter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to licenser
+# Contributing to license-reporter
 
 ## Issue contributions
 
 ### Did you find a bug ?
 
-Open a [new issue](https://github.com/bucharest-gold/licenser/issues/new)
+Open a [new issue](https://github.com/bucharest-gold/license-reporter/issues/new)
 and be sure to include a title and clear description, as much relevant information
 as possible, and a code sample or a test case demonstrating the expected behavior
 that is not occurring.
@@ -15,13 +15,13 @@ Discussions can be done via github issues or IRC channel #brass-monkey.
 
 ### Fork
 
-Fork the project [on GitHub](https://github.com/bucharest-gold/licenser)
+Fork the project [on GitHub](https://github.com/bucharest-gold/license-reporter)
 and check out your copy locally.
 
 ```
-git clone git@github.com:username/licenser.git
-cd licenser
-git remote add upstream https://github.com/bucharest-gold/licenser.git
+git clone git@github.com:username/license-reporter.git
+cd license-reporter
+git remote add upstream https://github.com/bucharest-gold/license-reporter.git
 ```
 
 ### Branch
@@ -88,5 +88,5 @@ npm it ; npm run lint
 git push origin my-contrib-branch
 ```
 
-Go to https://github.com/yourusername/licenser and select your feature branch.
+Go to https://github.com/yourusername/license-reporter and select your feature branch.
 Click the 'Pull Request' button and fill out the form.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# licenser
+# license-reporter
 
-[![Coverage Status](https://coveralls.io/repos/github/bucharest-gold/licenser/badge.svg?branch=master)](https://coveralls.io/github/bucharest-gold/licenser?branch=master)
-[![Build Status](https://travis-ci.org/bucharest-gold/licenser.svg?branch=master)](https://travis-ci.org/bucharest-gold/licenser)
-[![Code Climate](https://codeclimate.com/github/bucharest-gold/licenser/badges/gpa.svg)](https://codeclimate.com/github/bucharest-gold/licenser)
+[![Coverage Status](https://coveralls.io/repos/github/bucharest-gold/license-reporter/badge.svg?branch=master)](https://coveralls.io/github/bucharest-gold/license-reporter?branch=master)
+[![Build Status](https://travis-ci.org/bucharest-gold/license-reporter.svg?branch=master)](https://travis-ci.org/bucharest-gold/license-reporter)
+[![Code Climate](https://codeclimate.com/github/bucharest-gold/license-reporter/badges/gpa.svg)](https://codeclimate.com/github/bucharest-gold/license-reporter)
 
-Licenser is a tool that is intended to be used by Red Hat projects/products that require project dependency
+License-reporter is a tool that is intended to be used by Red Hat projects/products that require project dependency
 licenses to be retrieved and reported in xml and html format.
 
 ## Installation
@@ -18,8 +18,8 @@ npm link
 ## Usage
 
 ```
-$ licenser --help
-Usage: licenser /path/to/project [options]
+$ license-reporter --help
+Usage: license-reporter /path/to/project [options]
 
 Options:
   --version               Show version number                          [boolean]
@@ -53,7 +53,7 @@ Options:
 ```
 $ git clone https://github.com/bucharest-gold/szero.git
 $ cd szero ; npm install
-$ licenser --file=license1.xml
+$ license-reporter --file=license1.xml
 ```
 
 ```xml
@@ -92,7 +92,7 @@ $ licenser --file=license1.xml
 ```
 $ https://github.com/bucharest-gold/genet.git
 $ cd genet ; npm install
-$ licenser --file=license2.xml
+$ license-reporter --file=license2.xml
 ```
 
 ```xml
@@ -193,7 +193,7 @@ The intention for this functionality is to be able to create an xml file that co
 So we are going to merge both `license1.xml` and `license2.xml` files created by the previous examples.
 
 ```
-$ licenser --merge --merge-product-name="UberProject" --merge-license-xmls="./szero/license1.xml, ./genet/license2.xml" --merge-output="merged.xml" --silent
+$ license-reporter --merge --merge-product-name="UberProject" --merge-license-xmls="./szero/license1.xml, ./genet/license2.xml" --merge-output="merged.xml" --silent
 
 $ cat merged.xml
 ```
@@ -322,7 +322,7 @@ $ cat merged.xml
 </UberProject>
 ```
 
-## Licenser --all
+## License-reporter --all
 
 Also possible to generate a xml with licenses from all sub-modules:
 
@@ -330,7 +330,7 @@ Also possible to generate a xml with licenses from all sub-modules:
 
 ```
 cd szero
-$ licenser --all --file=all.xml
+$ license-reporter --all --file=all.xml
 $ du -s -h all.xml
 664K	all.xml
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -131,7 +131,7 @@ function showWarnings (options, declaredDependencies, xmlObject) {
                                     .length === 0);
   if (missingDependencies.length > 0) {
     console.log(`Dependencies found in package.json but not in xml: ${missingDependencies.join(',')}`);
-    console.log(`Please run 'licenser --ignore-version-range' to show all declared dependencies on generated xml.`);
+    console.log(`Please run 'license-reporter --ignore-version-range' to show all declared dependencies on generated xml.`);
   }
   warnings.print(unknown, 'UNKNOWN');
 

--- a/bin/license-reporter
+++ b/bin/license-reporter
@@ -3,7 +3,7 @@
 const cli = require('./cli.js');
 const yargs = require('yargs');
 const path = require('path');
-process.title = 'licenser';
+process.title = 'license-reporter';
 
 yargs
   .version(require('../package.json').version)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "licenser",
+  "name": "license-reporter",
   "version": "0.1.0",
-  "description": "Licenser gathers licence information and reports them in various formats.",
+  "description": "License-reporter gathers license information and reports them in various formats.",
   "main": "index.js",
   "scripts": {
     "test": "nyc tape test/*.js | tap-spec",
@@ -21,7 +21,7 @@
   "author": "Bucharest-gold",
   "repository": {
     "type": "git",
-    "url": "bucharest-gold/licenser"
+    "url": "bucharest-gold/license-reporter"
   },
   "dependencies": {
     "js2xmlparser": "^3.0.0",
@@ -49,6 +49,6 @@
   },
   "preferGlobal": true,
   "bin": {
-    "licenser": "./bin/licenser"
+    "licenser": "./bin/license-reporter"
   }
 }


### PR DESCRIPTION
This commit follows up on the renaming of the github repository to be
named license-reporter instead of licenser. The issue with the name
licenser was a name clash of an already existing npm module.