### PR TITLE
change the name of the binary file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "license-reporter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "License-reporter gathers license information and reports them in various formats.",
   "main": "index.js",
   "scripts": {
@@ -49,6 +49,6 @@
   },
   "preferGlobal": true,
   "bin": {
-    "licenser": "./bin/license-reporter"
+    "license-reporter": "./bin/license-reporter"
   }
 }


### PR DESCRIPTION
I missed the bin file which is still licenser which causes that name to
be installed as the binary executable when published.

I've also updated the version as I've already published 0.1.0.