### PR TITLE
src: support arrays of licenses in license field

### DIFF
--- a/lib/unknown.js
+++ b/lib/unknown.js
@@ -5,8 +5,16 @@ const unknown = 'UNKNOWN';
 module.exports.check = function (project) {
   return project.licenses.license.filter((license) => {
     let found = false;
-    if (unknownCheck(license.license)) {
-      license.license = unknown;
+    let licenses = license.license;
+    if (Array.isArray(licenses)) {
+      licenses.forEach((license) => {
+        if (unknownCheck(license)) {
+          license = unknown;
+          found = true;
+        }
+      });
+    } else if (unknownCheck(licenses)) {
+      licenses = unknown;
       found = true;
     }
     if (unknownCheck(license.file)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "licenser",
-  "version": "0.1.0",
+  "name": "license-reporter",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1383,7 +1383,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1396,7 +1396,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -1450,7 +1450,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -2072,7 +2072,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -2205,7 +2205,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -2266,7 +2266,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -4703,7 +4703,7 @@
     "read-package-json": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.10.tgz",
-      "integrity": "sha512-iNWaEs9hW9nviu5rHADmkm/Ob5dvah5zajtTS1XbyERSzkWgSwWZ6Z12bION7bEAzVc2YRFWnAz8k/tAr+5/eg==",
+      "integrity": "sha1-3AIp9t3mtLcFs54lstlw6+lWha4=",
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
@@ -4733,7 +4733,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -4915,7 +4915,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "sanitize-html": {
@@ -4932,7 +4932,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "semver": {
       "version": "5.3.0",
@@ -5264,7 +5264,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"

--- a/test/unknown-test.js
+++ b/test/unknown-test.js
@@ -12,11 +12,14 @@ test('Should warn if license is unknown', (t) => {
         {name: 'test2', version: '1.0', license: '', file: ''},
         {name: 'test3', version: '1.0', license: 'unknown', file: ''},
         {name: 'test4', version: '1.0', license: 'UNKNOWN', file: ''},
-        {name: 'test5', version: '1.2', license: undefined, file: undefined}
+        {name: 'test5', version: '1.2', license: undefined, file: undefined},
+        {name: 'test6', version: '1.0', license: ['MIT', 'APACHE'], file: 'something'},
+        {name: 'test7', version: '1.0', license: ['unknown'], file: 'something'},
+        {name: 'test8', version: '1.0', license: ['MIT', 'unknown'], file: 'something'}
       ]
     }
   };
   const unknown = require('../lib/unknown.js').check(project);
-  t.equal(unknown.length, 4);
+  t.equal(unknown.length, 6);
   t.end();
 });


### PR DESCRIPTION
Currently if a project specifies multiple licenses as an array the
following error will be reported:
```console
return value === undefined || value === '' || value.toUpperCase() ===
unknown;
                                                      ^
TypeError: value.toUpperCase is not a function
    at check
(/bucharest-gold/license-reporter/lib/unknown.js:37:55)
    at unknownCheck
(/bucharest-gold/license-reporter/lib/unknown.js:21:10)
    at project.licenses.license.filter
(/bucharest-gold/license-reporter/lib/unknown.js:8:9)
    at Array.filter (native)
    at Object.module.exports.check
(/bucharest-gold/license-reporter/lib/unknown.js:6:35)
    at Test.test
(/bucharest-gold/license-reporter/test/unknown-test.js:20:48)
    at Test.bound [as _cb]
(/bucharest-gold/license-reporter/node_modules/tape/lib/test.js:64:32)
    at Test.run
(/bucharest-gold/license-reporter/node_modules/tape/lib/test.js:83:10)
    at Test.bound [as run]
(/bucharest-gold/license-reporter/node_modules/tape/lib/test.js:64:32)
    at Immediate.next [as _onImmediate]
(/bucharest-gold/license-reporter/node_modules/tape/lib/results.js:71:15)
```
While I have to double check the issue repored in #84 I'm adding a Fixes
as I suspect the same error migth be causing this. I run the tool
against the same repository and not been able to reproduce the exact
error and with this commit I don't get any errors.

Fixes: https://github.com/bucharest-gold/license-reporter/issues/84