### PR TITLE
🐛 Fix printing of warning delimiters to console

### DIFF
--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -2,13 +2,13 @@
 
 function print (list, type) {
   if (list.length > 0) {
-    console.error(`========= WARNING ${type} LICENSES ==========`);
+    console.log(`========= WARNING ${type} LICENSES ==========`);
     list.forEach((license) => {
       console.log('name:', license.name,
            ', version:', license.version,
            ', licenses:', license.license);
     });
-    console.error(`========= WARNING ${type} LICENSES ==========`);
+    console.log(`========= WARNING ${type} LICENSES ==========`);
   }
 }
 


### PR DESCRIPTION
This is an OS-specific issue with the global console object's
methods. See [1] for more details.

[1] https://nodejs.org/api/process.html#process_a_note_on_process_i_o

It seems that if `process.stdout` and `process.stderr` are
asynchronous (this appears to be at least partly dependent on the OS),
then stdout and stderr could be interleaved when printed to the
console.

Before the warnings are logged, the XML output is logged to
stdout. Before this change, the warning block delimiters were being
printed to stderr, while the list of warnings was printed to
stdout. Given that on some systems they could be asynchronous, the
long XML output could still be being printed to stdout by the time
execution gets here to the warnings, so the titles can sometimes get
interleaved with that; but the list of warnings will always get done
at the end.

This change just changes the titles to also print to stdout, so
they'll always get printed in the right place. A better fix might be
to have a pure function to build up the output (either as a single
string, or a list of strings), then print the output of that
separately. This might make it easier for testing.