### PR TITLE
src: mark custom license as UNKNOWN

### DIFF
--- a/lib/unknown.js
+++ b/lib/unknown.js
@@ -5,16 +5,15 @@ const unknown = 'UNKNOWN';
 module.exports.check = function (project) {
   return project.licenses.license.filter((license) => {
     let found = false;
-    let licenses = license.license;
-    if (Array.isArray(licenses)) {
-      licenses.forEach((license) => {
-        if (unknownCheck(license)) {
-          license = unknown;
+    if (Array.isArray(license.license)) {
+      for (var i = 0; i < license.license.length; i++) {
+        if (unknownCheck(license.license[i])) {
+          license.license[i] = unknown;
           found = true;
         }
-      });
-    } else if (unknownCheck(licenses)) {
-      licenses = unknown;
+      }
+    } else if (unknownCheck(license.license)) {
+      license.license = unknown;
       found = true;
     }
     if (unknownCheck(license.file)) {
@@ -26,5 +25,8 @@ module.exports.check = function (project) {
 };
 
 function unknownCheck (value) {
-  return value === undefined || value === '' || value.toUpperCase() === unknown;
+  return value === undefined ||
+    value === '' ||
+    value.toUpperCase() === unknown ||
+    value.startsWith('Custom');
 }

--- a/test/unknown-test.js
+++ b/test/unknown-test.js
@@ -15,11 +15,13 @@ test('Should warn if license is unknown', (t) => {
         {name: 'test5', version: '1.2', license: undefined, file: undefined},
         {name: 'test6', version: '1.0', license: ['MIT', 'APACHE'], file: 'something'},
         {name: 'test7', version: '1.0', license: ['unknown'], file: 'something'},
-        {name: 'test8', version: '1.0', license: ['MIT', 'unknown'], file: 'something'}
+        {name: 'test8', version: '1.0', license: ['MIT', 'unknown'], file: 'something'},
+        {name: 'test9', version: '1.0', license: 'Custom: https://something', file: 'something'},
+        {name: 'test10', version: '1.0', license: ['Custom: https://something'], file: 'something'}
       ]
     }
   };
   const unknown = require('../lib/unknown.js').check(project);
-  t.equal(unknown.length, 6);
+  t.equal(unknown.length, 8);
   t.end();
 });


### PR DESCRIPTION
We have gotten feedback on the output of a custom license which simply
contains a link to the project in question. The request was to mark
such licenses as unknown instead.