### PR TITLE
src: don't include unknown licenses in whitelist

### DIFF
--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -4,6 +4,6 @@ const listchecker = require('./listchecker.js');
 
 module.exports = function (list) {
   return listchecker(require('./resources/default-whitelist.json'),
-                     (keys, license) => !keys[license],
+                     (keys, license) => !keys[license] && license.toUpperCase() !== 'UNKNOWN',
                      list);
 };

--- a/test/whitelist-test.js
+++ b/test/whitelist-test.js
@@ -10,7 +10,8 @@ test('Should warn if license is not in whitelist', (t) => {
       license: [
         {name: 'test1', version: '1.0', license: 'MIT', file: '...'},
         {name: 'test2', version: '1.2', license: 'Bogus', file: '...'},
-        {name: 'test2', version: '1.2', license: 'ASL 1.1', file: '...'}
+        {name: 'test2', version: '1.2', license: 'ASL 1.1', file: '...'},
+        {name: 'test2', version: '1.2', license: 'UNKNOWN', file: '...'}
       ]
     }
   };


### PR DESCRIPTION
Currently unknown license will also be included in the non-whitelisted
list causing them to be reported twice (also in the unknown list that
his).
This commit excludes unkown license from the whitelist.

Fixes: https://github.com/bucharest-gold/license-reporter/pull/96