### PR TITLE
src: support canonical license name mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   --merge-output          file to write the merged license info to
   --verbose               include the license content in the xml and not just
                           the path to the file                  [default: false]
+  --namemap               a file/url containing a mapping of license names
   --help                  Show help                                    [boolean]
 ```
 

--- a/bin/license-reporter
+++ b/bin/license-reporter
@@ -59,6 +59,9 @@ yargs
     describe: 'include the license content in the xml and not just the path to the file',
     default: false
   })
+  .option('namemap', {
+    describe: 'a file/url containing a mapping of license names'
+  })
   .help();
 
 const argv = yargs.argv;
@@ -78,7 +81,8 @@ var options = {
   mergeOutput: argv['merge-output'],
   ignoreVersionRange: argv['ignore-version-range'],
   unifiedlist: argv.unifiedlist,
-  verbose: argv.verbose
+  verbose: argv.verbose,
+  namemap: argv['namemap'],
 };
 
 if (!options.directory || options.directory === '.') {

--- a/lib/canonical-name.js
+++ b/lib/canonical-name.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const namesMap = new Map();
+
+function map (name) {
+  if (name.indexOf(',') !== -1) {
+    return name.split(',').map((name) => {
+      return get(name.trim());
+    }).join(', ');
+  }
+  return get(name);
+}
+
+function get (name) {
+  const mapped = namesMap.get(name);
+  if (mapped === undefined) {
+    return name;
+  }
+  if (Array.isArray(mapped)) {
+    return mapped.join(', ');
+  }
+  return mapped;
+}
+
+module.exports = function (list) {
+  if (!list) {
+    return { 'map': (name) => name };
+  }
+  for (const key in list) {
+    list[key].forEach((name) => {
+      namesMap.set(name, key);
+    });
+  }
+  return { 'map': map };
+};

--- a/lib/file-reader.js
+++ b/lib/file-reader.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+var request = require('sync-request');
 
 /**
  * This function reads a file.
@@ -11,6 +12,24 @@ const fs = require('fs');
 function readListFile (file) {
   if (file && fs.existsSync(file)) {
     return fs.readFileSync(file, 'utf8');
+  }
+  return null;
+}
+
+function readAsJson (url) {
+  if (url.startsWith('http')) {
+    const res = request('GET', url);
+    if (res.statusCode === 200) {
+      return JSON.parse(res.body.toString());
+    } else {
+      console.log('Could not get resource: ', url);
+      console.log('StatusCode returned was: ', res.statusCode);
+    }
+  } else {
+    const content = readListFile(url);
+    if (content !== null) {
+      return JSON.parse(content);
+    }
   }
   return null;
 }
@@ -34,5 +53,6 @@ function readLicenseFile (file) {
 
 module.exports = {
   readListFile,
-  readLicenseFile
+  readLicenseFile,
+  readAsJson
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,6 +269,11 @@
         }
       }
     },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
     "catharsis": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
@@ -368,6 +373,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "command-exists": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.2.tgz",
+      "integrity": "sha1-EoGcZPr5VEbsCuB/5sr7brNwiyI="
+    },
     "compare-func": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
@@ -387,7 +397,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -653,8 +662,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "4.0.2",
@@ -1219,6 +1227,16 @@
         "object-assign": "4.1.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -1306,6 +1324,11 @@
         "parse-github-repo-url": "1.4.0",
         "through2": "2.0.3"
       }
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -1465,6 +1488,21 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
       }
+    },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.0",
+        "http-response-object": "1.1.0"
+      }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "ignore": {
       "version": "3.3.3",
@@ -1683,6 +1721,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -1766,8 +1810,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2197,6 +2240,12 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -2225,6 +2274,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
       "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+      "dev": true
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
     "moment": {
@@ -4660,14 +4715,40 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "proxyquire": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -4679,6 +4760,11 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
+    },
+    "qs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
     },
     "re-emitter": {
       "version": "1.1.3",
@@ -4734,7 +4820,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4915,8 +5000,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-      "dev": true
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sanitize-html": {
       "version": "1.14.1",
@@ -5265,7 +5349,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -5347,6 +5430,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
       "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+    },
+    "sync-request": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-4.1.0.tgz",
+      "integrity": "sha512-iFbOBWYaznBNbheIKaMkj+3EabpEsXbuwcTVuYkRjoav+Om5L8VXXLIXms0cHxkouXMRCQaSfhfau9/HyIbM2Q==",
+      "requires": {
+        "command-exists": "1.2.2",
+        "concat-stream": "1.6.0",
+        "get-port": "3.2.0",
+        "http-response-object": "1.1.0",
+        "then-request": "2.2.0"
+      }
     },
     "table": {
       "version": "3.8.3",
@@ -5551,6 +5646,19 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.0",
+        "http-basic": "2.5.1",
+        "http-response-object": "1.1.0",
+        "promise": "7.3.1",
+        "qs": "6.5.0"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -5608,8 +5716,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -5713,8 +5820,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-extend": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "js2xmlparser": "^3.0.0",
     "license-checker": "^13.0.1",
     "mustache": "^2.3.0",
+    "sync-request": "^4.1.0",
     "xml2js": "^0.4.17",
     "yargs": "^8.0.2"
   },
@@ -42,6 +43,7 @@
     "jsdoc": "^3.4.2",
     "nsp": "^2.6.1",
     "nyc": "^11.0.2",
+    "proxyquire": "^1.8.0",
     "standard-version": "^3.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0",

--- a/test/canonical-name-test.js
+++ b/test/canonical-name-test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const test = require('tape');
+
+test('Should map license names to one defined in map file', (t) => {
+  const nameMap = {
+    'MIT License': ['The MIT License', 'MIT'],
+    'Some': ['Something']
+  };
+  const mapper = require('../lib/canonical-name.js')(nameMap);
+  t.equal(mapper.map('The MIT License'), 'MIT License', 'should map');
+  t.equal(mapper.map('MIT'), 'MIT License', 'should map');
+  t.equal(mapper.map('Something'), 'Some', 'should map');
+  t.equal(mapper.map('Bogus'), 'Bogus', 'unmapped should just pass through');
+  t.equal(mapper.map('MIT, AST'), 'MIT License, AST', 'should map comma separated');
+  t.end();
+});
+
+test('Should not map if nameMap is undefined', (t) => {
+  const mapper = require('../lib/canonical-name.js')();
+  t.equal(mapper.map('MIT'), 'MIT');
+  t.end();
+});


### PR DESCRIPTION
This commit allows license names to be renamed using by specifing a
mapping file containing a mapping of the license name to a canonical
name.