### PR TITLE
src: support version with dash postfix

### DIFF
--- a/lib/blacklist.js
+++ b/lib/blacklist.js
@@ -4,6 +4,6 @@ const listchecker = require('./listchecker.js');
 
 module.exports = function (list) {
   return listchecker(require('./resources/default-blacklist.json'),
-                     (keys, license) => keys[license],
+                     (keys, license) => keys[license.license.trim()],
                      list);
 };

--- a/lib/listchecker.js
+++ b/lib/listchecker.js
@@ -6,7 +6,7 @@ function check (keys, predicate) {
       if (typeof license.license === 'object') {
         license.license = license.license.join(',');
       }
-      return predicate(keys, license.license.trim());
+      return predicate(keys, license);
     });
   };
 }

--- a/lib/version-handler.js
+++ b/lib/version-handler.js
@@ -6,7 +6,7 @@ function fromNpmVersion (version) {
   // would be in the format @org/foo@1.1.0.
   if (nameVersion.length === 3) {
     return {
-      name: `${nameVersion[0]}${nameVersion[1]}`,
+      name: `@${nameVersion[0]}${nameVersion[1]}`,
       version: nameVersion[2]
     };
   }

--- a/lib/version-handler.js
+++ b/lib/version-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fromNpmVersionRegex = /^([@\w-./]+)@[~^]?([\d.]+)/;
+const fromNpmVersionRegex = /^([@\w-./]+)@[~^]?([\d.\-?]+)/;
 
 function fromNpmVersion (version) {
   const match = fromNpmVersionRegex.exec(version);

--- a/lib/version-handler.js
+++ b/lib/version-handler.js
@@ -1,16 +1,11 @@
 'use strict';
 
-const fromNpmVersionRegex = /^([@\w-./]+)@[~^]?([\d.\-?]+)/;
-
 function fromNpmVersion (version) {
-  const match = fromNpmVersionRegex.exec(version);
-  if (match) {
-    return {
-      name: match[1],
-      version: match[2]
-    };
-  }
-  return match;
+  const nameVersion = version.split('@');
+  return {
+    name: nameVersion[0],
+    version: nameVersion[1]
+  };
 }
 
 function fromNpmVersionIgnoreRange (version) {

--- a/lib/version-handler.js
+++ b/lib/version-handler.js
@@ -2,6 +2,14 @@
 
 function fromNpmVersion (version) {
   const nameVersion = version.split('@');
+  // Scoped packages might be used where the version
+  // would be in the format @org/foo@1.1.0.
+  if (nameVersion.length === 3) {
+    return {
+      name: `${nameVersion[0]}${nameVersion[1]}`,
+      version: nameVersion[2]
+    };
+  }
   return {
     name: nameVersion[0],
     version: nameVersion[1]

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -4,9 +4,11 @@ function print (list, type) {
   if (list.length > 0) {
     console.log(`========= WARNING ${type} LICENSES ==========`);
     list.forEach((license) => {
-      console.log('name:', license.name,
-           ', version:', license.version,
-           ', licenses:', license.license);
+      let msg = `name: ${license.name}, version: ${license.version}, licenses: ${license.license}`;
+      if (license.file === 'UNKNOWN') {
+        msg += `, file: ${license.file}`;
+      }
+      console.log(msg);
     });
     console.log(`========= WARNING ${type} LICENSES ==========`);
   }

--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -4,6 +4,16 @@ const listchecker = require('./listchecker.js');
 
 module.exports = function (list) {
   return listchecker(require('./resources/default-whitelist.json'),
-                     (keys, license) => !keys[license] && license.toUpperCase() !== 'UNKNOWN',
+                     (keys, license) => {
+                       // Don't include unknown license files, regardless of
+                       // whether they exist in the whitelist or not.
+                       // Let them be reported as unknown instead.
+                       if (license.file === 'UNKNOWN') {
+                         return false;
+                       }
+                       const name = license.license.trim();
+                       return !keys[name] &&
+                         name.toUpperCase().trim() !== 'UNKNOWN';
+                     },
                      list);
 };

--- a/test/unknown-test.js
+++ b/test/unknown-test.js
@@ -17,11 +17,12 @@ test('Should warn if license is unknown', (t) => {
         {name: 'test7', version: '1.0', license: ['unknown'], file: 'something'},
         {name: 'test8', version: '1.0', license: ['MIT', 'unknown'], file: 'something'},
         {name: 'test9', version: '1.0', license: 'Custom: https://something', file: 'something'},
-        {name: 'test10', version: '1.0', license: ['Custom: https://something'], file: 'something'}
+        {name: 'test10', version: '1.0', license: ['Custom: https://something'], file: 'something'},
+        {name: 'test11', version: '1.0-10', license: 'Apache-2.0', file: undefined}
       ]
     }
   };
   const unknown = require('../lib/unknown.js').check(project);
-  t.equal(unknown.length, 8);
+  t.equal(unknown.length, 9);
   t.end();
 });

--- a/test/version-handler-test.js
+++ b/test/version-handler-test.js
@@ -14,23 +14,28 @@ test('Should succeed matching npm version.', (t) => {
 test('Should fail matching npm version.', (t) => {
   t.plan(1);
   const result = versionHandler.fromNpmVersion('FooBar');
-  t.equal(null, result, 'the version not match.');
+  t.equal(undefined, result.version, 'the version not match.');
   t.end();
 });
 
 test('Should return as npm version.', (t) => {
   t.plan(2);
-  const npmVersion = versionHandler.asNpmVersion('foo', '3.2.1');
-  const result = versionHandler.fromNpmVersion(npmVersion);
+  const result = npmVersion('foo', '3.2.1');
   t.equal('foo', result.name, 'the name is OK.');
   t.equal('3.2.1', result.version, 'the version is OK.');
   t.end();
 });
 
-test('Should return as npm version with postfix.', (t) => {
-  t.plan(1);
-  const npmVersion = versionHandler.asNpmVersion('foo', '3.2.1-14');
-  const result = versionHandler.fromNpmVersion(npmVersion);
-  t.equal('3.2.1-14', result.version, 'the version is OK.');
+test('Should comply with semver spec.', (t) => {
+  t.plan(4);
+  t.equal('3.20.1-14', npmVersion('foo', '3.20.1-14').version);
+  t.equal('1.0.0-x.7.z.92', npmVersion('foo', '1.0.0-x.7.z.92').version);
+  t.equal('1.0.0-alpha+001', npmVersion('foo', '1.0.0-alpha+001').version);
+  t.equal('1.0.0+20130313144700', npmVersion('foo', '1.0.0+20130313144700').version);
   t.end();
 });
+
+function npmVersion (name, version) {
+  const npmVersion = versionHandler.asNpmVersion(name, version);
+  return versionHandler.fromNpmVersion(npmVersion);
+}

--- a/test/version-handler-test.js
+++ b/test/version-handler-test.js
@@ -38,7 +38,7 @@ test('Should comply with semver spec.', (t) => {
 test('Should work with scoped package naming', (t) => {
   t.plan(2);
   const result = npmVersion('@org/foo', '1.0.0+20130313144700');
-  t.equal('org/foo', result.name);
+  t.equal('@org/foo', result.name);
   t.equal('1.0.0+20130313144700', result.version);
   t.end();
 });

--- a/test/version-handler-test.js
+++ b/test/version-handler-test.js
@@ -26,3 +26,11 @@ test('Should return as npm version.', (t) => {
   t.equal('3.2.1', result.version, 'the version is OK.');
   t.end();
 });
+
+test('Should return as npm version with postfix.', (t) => {
+  t.plan(1);
+  const npmVersion = versionHandler.asNpmVersion('foo', '3.2.1-14');
+  const result = versionHandler.fromNpmVersion(npmVersion);
+  t.equal('3.2.1-14', result.version, 'the version is OK.');
+  t.end();
+});

--- a/test/version-handler-test.js
+++ b/test/version-handler-test.js
@@ -35,6 +35,14 @@ test('Should comply with semver spec.', (t) => {
   t.end();
 });
 
+test('Should work with scoped package naming', (t) => {
+  t.plan(2);
+  const result = npmVersion('@org/foo', '1.0.0+20130313144700');
+  t.equal('org/foo', result.name);
+  t.equal('1.0.0+20130313144700', result.version);
+  t.end();
+});
+
 function npmVersion (name, version) {
   const npmVersion = versionHandler.asNpmVersion(name, version);
   return versionHandler.fromNpmVersion(npmVersion);

--- a/test/warnings-test.js
+++ b/test/warnings-test.js
@@ -4,19 +4,19 @@ const test = require('tape');
 const warnings = require('../lib/warnings.js');
 const stdout = require('test-console').stdout;
 
-const expected = ['========= WARNING WHITE-LISTED LICENSES ==========\n',
-  'name: test2 , version: 1.2 , licenses: Bogus\n',
-  '========= WARNING WHITE-LISTED LICENSES ==========\n'];
-
 test('Should report the correct warning.', (t) => {
   t.plan(1);
+  const expected = ['========= WARNING WHITE-LISTED LICENSES ==========\n',
+    'name: test2, version: 1.2, licenses: Bogus\n',
+    '========= WARNING WHITE-LISTED LICENSES ==========\n'];
   const project = {
     name: 'testProject',
     licenses: {
       license: [
        {name: 'test1', version: '1.0', license: 'MIT', file: '...'},
        {name: 'test2', version: '1.2', license: 'Bogus', file: '...'},
-       {name: 'test2', version: '1.2', license: 'ASL 1.1', file: '...'}
+       {name: 'test2', version: '1.2', license: 'ASL 1.1', file: '...'},
+       {name: 'test4', version: '1.2', license: 'ASL 1.1', file: 'UNKNOWN'}
       ]
     }
   };
@@ -24,6 +24,27 @@ test('Should report the correct warning.', (t) => {
   const whitelist = [{'name': 'ASL 1.1'}];
   const log = stdout.inspectSync(() => warnings.print(require('../lib/whitelist.js')(whitelist).check(project),
                  'WHITE-LISTED'));
+  t.deepEqual(log, expected);
+  t.end();
+});
+
+test('Should report the correct unknown warning.', (t) => {
+  t.plan(1);
+  const expected = ['========= WARNING UNKNOWN LICENSES ==========\n',
+    'name: test2, version: 1.2, licenses: Apache-2.0, file: UNKNOWN\n',
+    '========= WARNING UNKNOWN LICENSES ==========\n'];
+  const project = {
+    name: 'testProject',
+    licenses: {
+      license: [
+       {name: 'test1', version: '1.2', license: 'ASL 1.1', file: '...'},
+       {name: 'test2', version: '1.2', license: 'Apache-2.0', file: 'UNKNOWN'}
+      ]
+    }
+  };
+
+  const log = stdout.inspectSync(() => warnings.print(require('../lib/unknown.js').check(project),
+                 'UNKNOWN'));
   t.deepEqual(log, expected);
   t.end();
 });

--- a/test/whitelist-test.js
+++ b/test/whitelist-test.js
@@ -11,7 +11,8 @@ test('Should warn if license is not in whitelist', (t) => {
         {name: 'test1', version: '1.0', license: 'MIT', file: '...'},
         {name: 'test2', version: '1.2', license: 'Bogus', file: '...'},
         {name: 'test2', version: '1.2', license: 'ASL 1.1', file: '...'},
-        {name: 'test2', version: '1.2', license: 'UNKNOWN', file: '...'}
+        {name: 'test2', version: '1.2', license: 'UNKNOWN', file: '...'},
+        {name: 'test2', version: '1.2', license: 'Apache-2.0', file: 'UNKNOWN'}
       ]
     }
   };


### PR DESCRIPTION
Currently, if a dependency has a version with a postfix version number,
for example ups-admin-ui has the version 1.1.4-10 the `-10` was not
taken into account when determining the version.

This commit fixes the above issue and also fixes the issue that this
version was included in both the unknown list (as it does not have a
license that was detected) and in the whitelist. The issue here was that
the while list only inspected the actual license name and ignored the
license file. It now checks the license file and if it is unknown does
not report it as whitelisted, instead the unknown list will report this
license.

Fixes: https://github.com/bucharest-gold/license-reporter/issues/99