### PR TITLE
src: make approved warnings message consistent

### DIFF
--- a/lib/unifiedlist.js
+++ b/lib/unifiedlist.js
@@ -50,23 +50,23 @@ function check (xmlObject) {
   });
 
   if (approvedFound.size > 0) {
-    console.error(`========= APPROVED LICENSES ==========`);
+    console.error(`========= APPROVED LICENSES        ==========`);
     Array.from(new Set(approvedFound)).forEach((license) => {
       console.log('name:', license.name,
            ', version:', license.version,
            ', licenses:', license.license);
     });
-    console.error(`========= APPROVED LICENSES ==========`);
+    console.error(`========= APPROVED LICENSES        ==========`);
   }
 
   if (notApprovedFound.size > 0) {
-    console.error(`========= NOT APPROVED LICENSES ==========`);
+    console.error(`========= NOT APPROVED LICENSES    ==========`);
     Array.from(new Set(notApprovedFound)).forEach((license) => {
       console.log('name:', license.name,
            ', version:', license.version,
            ', licenses:', license.license);
     });
-    console.error(`========= NOT APPROVED LICENSES ==========`);
+    console.error(`========= NOT APPROVED LICENSES    ==========`);
   }
 }
 


### PR DESCRIPTION
Currently, the warning message for approved/not approved licenses does
not line up with any unknown licenses found making the output look
sloppy.

This commit makes the headers consistent.