### PR TITLE
src: use license url instead of file path

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,7 @@ const reader = require('../lib/file-reader.js');
 const js2xmlparser = require('js2xmlparser');
 const fs = require('fs');
 const path = require('path');
+const unifiedlist = require('../lib/unifiedlist.js');
 
 // Gets the project name from package.json.
 const projectName = (options) => require(`${options.directory}/package.json`).name;
@@ -48,14 +49,15 @@ function createHtml (options, xmlObject) {
 //    <file> file content here. </file>
 //  </license>
 const entry = (info, dependency, options) => {
+  const canonicalName = canonicalNameMapper.map(info.licenses);
+  const url = unifiedlist.urlForName(canonicalName);
   return {
     packageName: dependency.name,
     version: dependency.version,
     licenses: {
       license: [{
-        name: canonicalNameMapper.map(info.licenses),
-        url: options.verbose ? reader.readLicenseFile(info.licenseFile)
-          : info.licenseFile
+        name: canonicalName,
+        url: options.verbose ? reader.readLicenseFile(info.licenseFile) : url
       }]
     }
   };
@@ -143,7 +145,6 @@ function showWarnings (options, declaredDependencies, xmlObject) {
     console.log(`Please run 'license-reporter --ignore-version-range' to show all declared dependencies on generated xml.`);
   }
   warnings.print(unknown, 'UNKNOWN');
-  const unifiedlist = require('../lib/unifiedlist.js');
   unifiedlist.check(xmlObject);
 }
 

--- a/bin/license-reporter
+++ b/bin/license-reporter
@@ -52,7 +52,8 @@ yargs
     default: false
   })
   .option('namemap', {
-    describe: 'a file/url containing a mapping of license names'
+    describe: 'a file/url containing a mapping of license names',
+    default: path.join(__dirname, '../lib/resources/default-canonicalnames.json')
   })
   .help();
 
@@ -72,7 +73,7 @@ var options = {
   ignoreVersionRange: argv['ignore-version-range'],
   unifiedlist: argv.unifiedlist,
   verbose: argv.verbose,
-  namemap: argv['namemap'],
+  namemap: path.resolve(argv.namemap),
 };
 
 if (!options.directory || options.directory === '.') {

--- a/lib/canonical-name.js
+++ b/lib/canonical-name.js
@@ -14,7 +14,7 @@ function map (name) {
 function get (name) {
   const mapped = namesMap.get(name);
   if (mapped === undefined) {
-    return name;
+    return 'UNKNOWN';
   }
   if (Array.isArray(mapped)) {
     return mapped.join(', ');

--- a/lib/resources/default-canonicalnames.json
+++ b/lib/resources/default-canonicalnames.json
@@ -1,0 +1,1097 @@
+{
+  "#official SPDX full name if license is in SPDX list#": [
+    "#official SPDX abbreviation if license is in SPDX list#",
+    "#alias of license#"
+  ],
+  "3dfx Glide License": [
+    "Glide"
+  ],
+  "AMD's plpa_map.c License": [
+    "AMDPLPA"
+  ],
+  "ANTLR Software Rights Notice": [
+    "ANTLR-PD"
+  ],
+  "Abstyles License": [
+    "Abstyles"
+  ],
+  "Academic Free License v1.1": [
+    "AFL-1.1"
+  ],
+  "Academic Free License v1.2": [
+    "AFL-1.2"
+  ],
+  "Academic Free License v2.0": [
+    "AFL-2.0"
+  ],
+  "Academic Free License v2.1": [
+    "AFL-2.1"
+  ],
+  "Academic Free License v3.0": [
+    "AFL-3.0"
+  ],
+  "Academy of Motion Picture Arts and Sciences BSD": [
+    "AMPAS"
+  ],
+  "Adaptive Public License 1.0": [
+    "APL-1.0"
+  ],
+  "Adobe Glyph List License": [
+    "Adobe-Glyph"
+  ],
+  "Adobe Postscript AFM License": [
+    "APAFML"
+  ],
+  "Adobe Systems Incorporated Source Code License Agreement": [
+    "Adobe-2006"
+  ],
+  "Affero General Public License v1.0": [
+    "Affero General Public License 1.0",
+    "AGPL-1.0"
+  ],
+  "Afmparse License": [
+    "Afmparse"
+  ],
+  "Aladdin Free Public License": [
+    "Aladdin"
+  ],
+  "Amazon Digital Services License": [
+    "ADSL"
+  ],
+  "Apache License 1.0": [
+    "Apache Software License 1.0",
+    "Apache-1.0"
+  ],
+  "Apache License 1.1": [
+    "Apache Software License 1.1",
+    "Apache-1.1"
+  ],
+  "Apache License 2.0": [
+    "The Apache License, Version 2.0",
+    "apache-2.0",
+    "Apache License Version 2.0",
+    "Apache Software License, Version 2.0",
+    "Apache v2",
+    "The Apache Software License, Version 2.0",
+    "Apache License, Version 2.0",
+    "Apache-2.0",
+    "Apache Software License 2.0"
+  ],
+  "Apple MIT License": [
+    "AML"
+  ],
+  "Apple Public Source License 1.0": [
+    "APSL-1.0"
+  ],
+  "Apple Public Source License 1.1": [
+    "APSL-1.1"
+  ],
+  "Apple Public Source License 1.2": [
+    "APSL-1.2"
+  ],
+  "Apple Public Source License 2.0": [
+    "APSL-2.0"
+  ],
+  "Artistic License 1.0": [
+    "Artistic-1.0"
+  ],
+  "Artistic License 1.0 (Perl)": [
+    "Artistic-1.0-Perl"
+  ],
+  "Artistic License 1.0 w/clause 8": [
+    "Artistic-1.0-cl8"
+  ],
+  "Artistic License 2.0": [
+    "Artistic-2.0",
+    "Artistic 2.0"
+  ],
+  "Attribution Assurance License": [
+    "AAL"
+  ],
+  "BSD 2-clause \"Simplified\" License": [
+    "BSD-2-Clause"
+  ],
+  "BSD 2-clause FreeBSD License": [
+    "BSD-2-Clause-FreeBSD"
+  ],
+  "BSD 2-clause NetBSD License": [
+    "BSD-2-Clause-NetBSD"
+  ],
+  "BSD 3-Clause No Nuclear License": [
+    "BSD-3-Clause-No-Nuclear-License"
+  ],
+  "BSD 3-Clause No Nuclear License 2014": [
+    "BSD-3-Clause-No-Nuclear-License-2014"
+  ],
+  "BSD 3-Clause No Nuclear Warranty": [
+    "BSD-3-Clause-No-Nuclear-Warranty"
+  ],
+  "BSD 3-clause \"New\" or \"Revised\" License": [
+    "BSD-3-Clause"
+  ],
+  "BSD 3-clause Clear License": [
+    "BSD-3-Clause-Clear"
+  ],
+  "BSD 4-clause \"Original\" or \"Old\" License": [
+    "BSD-4-Clause"
+  ],
+  "BSD Protection License": [
+    "BSD-Protection"
+  ],
+  "BSD Source Code Attribution": [
+    "BSD-Source-Code"
+  ],
+  "BSD Zero Clause License": [
+    "0BSD"
+  ],
+  "BSD with attribution": [
+    "BSD-3-Clause-Attribution"
+  ],
+  "BSD-4-Clause (University of California-Specific)": [
+    "BSD-4-Clause-UC"
+  ],
+  "Bahyph License": [
+    "Bahyph"
+  ],
+  "Barr License": [
+    "Barr"
+  ],
+  "Beerware License": [
+    "Beerware"
+  ],
+  "BitTorrent Open Source License v1.0": [
+    "BitTorrent-1.0"
+  ],
+  "BitTorrent Open Source License v1.1": [
+    "BitTorrent-1.1"
+  ],
+  "Boost Software License 1.0": [
+    "BSL-1.0"
+  ],
+  "Borceux license": [
+    "Borceux"
+  ],
+  "CMU License": [
+    "MIT-CMU"
+  ],
+  "CNRI Jython License": [
+    "CNRI-Jython"
+  ],
+  "CNRI Python License": [
+    "CNRI-Python"
+  ],
+  "CNRI Python Open Source GPL Compatible License Agreement": [
+    "CNRI-Python-GPL-Compatible"
+  ],
+  "CUA Office Public License v1.0": [
+    "CUA-OPL-1.0",
+    "CUA Office Public License Version 1.0"
+  ],
+  "Caldera License": [
+    "Caldera"
+  ],
+  "CeCILL Free Software License Agreement v1.0": [
+    "CECILL-1.0"
+  ],
+  "CeCILL Free Software License Agreement v1.1": [
+    "CeCILL License v1.1",
+    "CECILL-1.1"
+  ],
+  "CeCILL Free Software License Agreement v2.0": [
+    "CeCILL License v2",
+    "CECILL-2.0"
+  ],
+  "CeCILL Free Software License Agreement v2.1": [
+    "CECILL-2.1"
+  ],
+  "CeCILL-B Free Software License Agreement": [
+    "CeCILL-B License",
+    "CECILL-B"
+  ],
+  "CeCILL-C Free Software License Agreement": [
+    "CECILL-C",
+    "CeCILL-C License"
+  ],
+  "Clarified Artistic License": [
+    "ClArtistic"
+  ],
+  "Code Project Open License 1.02": [
+    "CPOL-1.02"
+  ],
+  "Common Development Distribution License": [
+    "Common Development and Distribution License"
+  ],
+  "Common Development and Distribution License 1.0": [
+    "CDDL-1.0"
+  ],
+  "Common Development and Distribution License 1.1": [
+    "CDDL-1.1",
+    "Common Development and Distribution License version 1.1"
+  ],
+  "Common Public Attribution License 1.0": [
+    "CPAL-1.0"
+  ],
+  "Common Public License 1.0": [
+    "Common Public License, Version 1.0",
+    "CPL-1.0"
+  ],
+  "Computer Associates Trusted Open Source License 1.1": [
+    "CATOSL-1.1"
+  ],
+  "Condor Public License v1.1": [
+    "Condor-1.1"
+  ],
+  "Creative Commons Attribution 1.0": [
+    "CC-BY-1.0"
+  ],
+  "Creative Commons Attribution 2.0": [
+    "CC-BY-2.0"
+  ],
+  "Creative Commons Attribution 2.5": [
+    "CC-BY-2.5"
+  ],
+  "Creative Commons Attribution 3.0": [
+    "CC-BY-3.0"
+  ],
+  "Creative Commons Attribution 4.0": [
+    "CC-BY-4.0"
+  ],
+  "Creative Commons Attribution No Derivatives 1.0": [
+    "CC-BY-ND-1.0"
+  ],
+  "Creative Commons Attribution No Derivatives 2.0": [
+    "CC-BY-ND-2.0"
+  ],
+  "Creative Commons Attribution No Derivatives 2.5": [
+    "CC-BY-ND-2.5"
+  ],
+  "Creative Commons Attribution No Derivatives 3.0": [
+    "CC-BY-ND-3.0"
+  ],
+  "Creative Commons Attribution No Derivatives 4.0": [
+    "CC-BY-ND-4.0"
+  ],
+  "Creative Commons Attribution Non Commercial 1.0": [
+    "CC-BY-NC-1.0"
+  ],
+  "Creative Commons Attribution Non Commercial 2.0": [
+    "CC-BY-NC-2.0"
+  ],
+  "Creative Commons Attribution Non Commercial 2.5": [
+    "CC-BY-NC-2.5"
+  ],
+  "Creative Commons Attribution Non Commercial 3.0": [
+    "CC-BY-NC-3.0"
+  ],
+  "Creative Commons Attribution Non Commercial 4.0": [
+    "CC-BY-NC-4.0"
+  ],
+  "Creative Commons Attribution Non Commercial No Derivatives 1.0": [
+    "CC-BY-NC-ND-1.0"
+  ],
+  "Creative Commons Attribution Non Commercial No Derivatives 2.0": [
+    "CC-BY-NC-ND-2.0"
+  ],
+  "Creative Commons Attribution Non Commercial No Derivatives 2.5": [
+    "CC-BY-NC-ND-2.5"
+  ],
+  "Creative Commons Attribution Non Commercial No Derivatives 3.0": [
+    "CC-BY-NC-ND-3.0"
+  ],
+  "Creative Commons Attribution Non Commercial No Derivatives 4.0": [
+    "CC-BY-NC-ND-4.0"
+  ],
+  "Creative Commons Attribution Non Commercial Share Alike 1.0": [
+    "CC-BY-NC-SA-1.0"
+  ],
+  "Creative Commons Attribution Non Commercial Share Alike 2.0": [
+    "CC-BY-NC-SA-2.0"
+  ],
+  "Creative Commons Attribution Non Commercial Share Alike 2.5": [
+    "CC-BY-NC-SA-2.5"
+  ],
+  "Creative Commons Attribution Non Commercial Share Alike 3.0": [
+    "CC-BY-NC-SA-3.0"
+  ],
+  "Creative Commons Attribution Non Commercial Share Alike 4.0": [
+    "CC-BY-NC-SA-4.0"
+  ],
+  "Creative Commons Attribution Share Alike 1.0": [
+    "CC-BY-SA-1.0"
+  ],
+  "Creative Commons Attribution Share Alike 2.0": [
+    "CC-BY-SA-2.0"
+  ],
+  "Creative Commons Attribution Share Alike 2.5": [
+    "CC-BY-SA-2.5"
+  ],
+  "Creative Commons Attribution Share Alike 3.0": [
+    "CC-BY-SA-3.0"
+  ],
+  "Creative Commons Attribution Share Alike 4.0": [
+    "CC-BY-SA-4.0"
+  ],
+  "Creative Commons Zero v1.0 Universal": [
+    "CC0-1.0",
+    "Public Domain, per Creative Commons CC0",
+    "Creative Commons Zero 1.0 Universal"
+  ],
+  "Crossword License": [
+    "Crossword"
+  ],
+  "CrystalStacker License": [
+    "Crystal Stacker License",
+    "CrystalStacker"
+  ],
+  "Cube License": [
+    "Cube"
+  ],
+  "DSDP License": [
+    "DSDP"
+  ],
+  "Deutsche Freie Software Lizenz": [
+    "D-FSL-1.0"
+  ],
+  "Do What The F*ck You Want To Public License": [
+    "WTFPL"
+  ],
+  "Dotseqn License": [
+    "Dotseqn"
+  ],
+  "EU DataGrid Software License": [
+    "EU Datagrid Software License",
+    "EUDatagrid"
+  ],
+  "Eclipse Distribution License 1.0": [
+    "Eclipse Distribution License, Version 1.0"
+  ],
+  "Eclipse Public License 1.0": [
+    "Eclipse Public License, Version 1.0",
+    "EPL-1.0",
+    "Eclipse Public License - v 1.0"
+  ],
+  "Educational Community License v1.0": [
+    "Educational Community License 1.0",
+    "ECL-1.0"
+  ],
+  "Educational Community License v2.0": [
+    "ECL-2.0",
+    "Educational Community License 2.0"
+  ],
+  "Eiffel Forum License v1.0": [
+    "EFL-1.0",
+    "Eiffel Forum License 1.0"
+  ],
+  "Eiffel Forum License v2.0": [
+    "Eiffel Forum License 2.0",
+    "EFL-2.0"
+  ],
+  "Enlightenment License (e16)": [
+    "MIT-advertising"
+  ],
+  "Entessa Public License v1.0": [
+    "Entessa"
+  ],
+  "Erlang Public License v1.1": [
+    "Erlang Public License 1.1",
+    "ErlPL-1.1"
+  ],
+  "European Union Public License 1.0": [
+    "EUPL-1.0",
+    "European Union Public License v1.0"
+  ],
+  "European Union Public License 1.1": [
+    "EUPL-1.1"
+  ],
+  "Eurosym License": [
+    "Eurosym"
+  ],
+  "FSF All Permissive License": [
+    "FSFAP"
+  ],
+  "FSF Unlimited License": [
+    "FSFUL"
+  ],
+  "FSF Unlimited License (with License Retention)": [
+    "FSFULLR"
+  ],
+  "Fair License": [
+    "Fair"
+  ],
+  "Frameworx Open License 1.0": [
+    "Frameworx-1.0"
+  ],
+  "FreeImage Public License v1.0": [
+    "FreeImage"
+  ],
+  "Freetype Project License": [
+    "FTL"
+  ],
+  "GL2PS License": [
+    "GL2PS"
+  ],
+  "GNU Affero General Public License v3.0": [
+    "AGPL-3.0"
+  ],
+  "GNU Free Documentation License v1.1": [
+    "GFDL-1.1"
+  ],
+  "GNU Free Documentation License v1.2": [
+    "GFDL-1.2"
+  ],
+  "GNU Free Documentation License v1.3": [
+    "GFDL-1.3"
+  ],
+  "GNU General Public License v1.0 only": [
+    "GPL-1.0"
+  ],
+  "GNU General Public License v1.0 or later": [
+    "GPL-1.0+"
+  ],
+  "GNU General Public License v2.0 only": [
+    "GPL-2.0"
+  ],
+  "GNU General Public License v2.0 or later": [
+    "GPL-2.0+"
+  ],
+  "GNU General Public License v2.0 w/Autoconf exception": [
+    "GPL-2.0-with-autoconf-exception"
+  ],
+  "GNU General Public License v2.0 w/Bison exception": [
+    "GPL-2.0-with-bison-exception"
+  ],
+  "GNU General Public License v2.0 w/Classpath exception": [
+    "GNU General Public License v2.0 only, with Classpath exception",
+    "GPL-2.0-with-classpath-exception"
+  ],
+  "GNU General Public License v2.0 w/Font exception": [
+    "GNU General Public License v2.0 only, with font embedding exception",
+    "GPL-2.0-with-font-exception"
+  ],
+  "GNU General Public License v2.0 w/GCC Runtime Library exception": [
+    "GPL-2.0-with-GCC-exception"
+  ],
+  "GNU General Public License v3.0 only": [
+    "GPL-3.0"
+  ],
+  "GNU General Public License v3.0 or later": [
+    "GPL-3.0+"
+  ],
+  "GNU General Public License v3.0 w/Autoconf exception": [
+    "GPL-3.0-with-autoconf-exception"
+  ],
+  "GNU General Public License v3.0 w/GCC Runtime Library exception": [
+    "GPL-3.0-with-GCC-exception"
+  ],
+  "GNU Lesser General Public License v2.1 only": [
+    "LGPL-2.1",
+    "LGPL 2.1"
+  ],
+  "GNU Lesser General Public License v2.1 or later": [
+    "LGPL-2.1+"
+  ],
+  "GNU Lesser General Public License v3.0 only": [
+    "GNU Lesser General Public License, Version 3",
+    "LGPL-3.0"
+  ],
+  "GNU Lesser General Public License v3.0 or later": [
+    "LGPL-3.0+",
+    "GNU Lesser General Public License v3.0 or later, with exceptions"
+  ],
+  "GNU Library General Public License v2 only": [
+    "GNU Library General Public License, Version 2",
+    "LGPL-2.0"
+  ],
+  "GNU Library General Public License v2 or later": [
+    "LGPL-2.0+"
+  ],
+  "Giftware License": [
+    "Giftware"
+  ],
+  "Glulxe License": [
+    "Glulxe"
+  ],
+  "Haskell Language Report License": [
+    "HaskellReport"
+  ],
+  "Historic Permission Notice and Disclaimer": [
+    "HPND",
+    "Historical Permission Notice and Disclaimer"
+  ],
+  "IBM PowerPC Initialization and Boot Software": [
+    "IBM-pibs"
+  ],
+  "IBM Public License v1.0": [
+    "IPL-1.0"
+  ],
+  "ICU License": [
+    "ICU",
+    "ICU License - ICU 1.8.1 to ICU 57.1"
+  ],
+  "IPA Font License": [
+    "IPA"
+  ],
+  "ISC License": [
+    "ISC"
+  ],
+  "ImageMagick License": [
+    "ImageMagick"
+  ],
+  "Imlib2 License": [
+    "Imlib2"
+  ],
+  "Independent JPEG Group License": [
+    "IJG"
+  ],
+  "Info-ZIP License": [
+    "Info-ZIP"
+  ],
+  "Intel ACPI Software License Agreement": [
+    "Intel-ACPI"
+  ],
+  "Intel Open Source License": [
+    "Intel"
+  ],
+  "Interbase Public License v1.0": [
+    "Interbase-1.0"
+  ],
+  "JSON License": [
+    "JSON"
+  ],
+  "JasPer License": [
+    "JasPer-2.0"
+  ],
+  "LaTeX Project Public License v1.0": [
+    "LPPL-1.0"
+  ],
+  "LaTeX Project Public License v1.1": [
+    "LPPL-1.1"
+  ],
+  "LaTeX Project Public License v1.2": [
+    "LPPL-1.2"
+  ],
+  "LaTeX Project Public License v1.3a": [
+    "LPPL-1.3a"
+  ],
+  "LaTeX Project Public License v1.3c": [
+    "LPPL-1.3c"
+  ],
+  "Latex2e License": [
+    "Latex2e"
+  ],
+  "Lawrence Berkeley National Labs BSD variant license": [
+    "BSD-3-Clause-LBNL"
+  ],
+  "Leptonica License": [
+    "Leptonica"
+  ],
+  "Lesser General Public License For Linguistic Resources": [
+    "LGPLLR"
+  ],
+  "Licence Art Libre 1.2": [
+    "LAL-1.2"
+  ],
+  "Licence Art Libre 1.3": [
+    "LAL-1.3"
+  ],
+  "Licence Libre du Qu\u00e9bec \u2013 Permissive version 1.1": [
+    "LiLiQ-P-1.1"
+  ],
+  "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 forte version 1.1": [
+    "LiLiQ-Rplus-1.1"
+  ],
+  "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 version 1.1": [
+    "LiLiQ-R-1.1"
+  ],
+  "Lucent Public License Version 1.0": [
+    "LPL-1.0"
+  ],
+  "Lucent Public License v1.02": [
+    "LPL-1.02"
+  ],
+  "MIT +no-false-attribs license": [
+    "MITNFA"
+  ],
+  "MIT License": [
+    "The MIT License",
+    "MIT"
+  ],
+  "MakeIndex License": [
+    "MakeIndex"
+  ],
+  "Matrix Template Library License": [
+    "MTLL"
+  ],
+  "Microsoft Public License": [
+    "MS-PL"
+  ],
+  "Microsoft Reciprocal License": [
+    "MS-RL"
+  ],
+  "MirOS Licence": [
+    "MirOS",
+    "MirOS License"
+  ],
+  "Motosoto License": [
+    "Motosoto"
+  ],
+  "Mozilla Public License 1.0": [
+    "Mozilla Public License v1.0",
+    "MPL-1.0"
+  ],
+  "Mozilla Public License 1.1": [
+    "Mozilla Public License v1.1",
+    "MPL-1.1",
+    "MPL 1.1",
+    "Mozilla Public License, Version 1.1"
+  ],
+  "Mozilla Public License 2.0": [
+    "MPL-2.0",
+    "Mozilla Public License v2.0"
+  ],
+  "Mozilla Public License 2.0 (no copyleft exception)": [
+    "MPL-2.0-no-copyleft-exception"
+  ],
+  "Multics License": [
+    "Multics"
+  ],
+  "Mup License": [
+    "Mup"
+  ],
+  "NASA Open Source Agreement 1.3": [
+    "NASA Open Source Agreement v1.3",
+    "NASA-1.3"
+  ],
+  "NRL License": [
+    "NRL"
+  ],
+  "NTP License": [
+    "NTP"
+  ],
+  "Naumen Public License": [
+    "Naumen"
+  ],
+  "Net Boolean Public License v1": [
+    "NBPL-1.0"
+  ],
+  "Net-SNMP License": [
+    "Net-SNMP"
+  ],
+  "NetCDF license": [
+    "NetCDF"
+  ],
+  "Nethack General Public License": [
+    "NGPL"
+  ],
+  "Netizen Open Source License": [
+    "NOSL"
+  ],
+  "Netscape Public License v1.0": [
+    "NPL-1.0"
+  ],
+  "Netscape Public License v1.1": [
+    "NPL-1.1"
+  ],
+  "Newsletr License": [
+    "Newsletr"
+  ],
+  "No Limit Public License": [
+    "NLPL"
+  ],
+  "Nokia Open Source License": [
+    "Nokia"
+  ],
+  "Non-Profit Open Software License 3.0": [
+    "NPOSL-3.0"
+  ],
+  "Norwegian Licence for Open Government Data": [
+    "NLOD-1.0"
+  ],
+  "Noweb License": [
+    "Noweb"
+  ],
+  "Nunit License": [
+    "Nunit"
+  ],
+  "OCLC Research Public License 2.0": [
+    "OCLC-2.0",
+    "OCLC Public Research License 2.0"
+  ],
+  "ODC Open Database License v1.0": [
+    "ODbL-1.0"
+  ],
+  "ODC Public Domain Dedication & License 1.0": [
+    "PDDL-1.0"
+  ],
+  "OSET Public License version 2.1": [
+    "OSET-PL-2.1"
+  ],
+  "Open CASCADE Technology Public License": [
+    "OCCT-PL"
+  ],
+  "Open Group Test Suite License": [
+    "OGTSL"
+  ],
+  "Open LDAP Public License 2.2.2": [
+    "OLDAP-2.2.2"
+  ],
+  "Open LDAP Public License v1.1": [
+    "OLDAP-1.1"
+  ],
+  "Open LDAP Public License v1.2": [
+    "OLDAP-1.2"
+  ],
+  "Open LDAP Public License v1.3": [
+    "OLDAP-1.3"
+  ],
+  "Open LDAP Public License v1.4": [
+    "OLDAP-1.4"
+  ],
+  "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)": [
+    "OLDAP-2.0"
+  ],
+  "Open LDAP Public License v2.0.1": [
+    "OLDAP-2.0.1"
+  ],
+  "Open LDAP Public License v2.1": [
+    "OLDAP-2.1"
+  ],
+  "Open LDAP Public License v2.2": [
+    "OLDAP-2.2"
+  ],
+  "Open LDAP Public License v2.2.1": [
+    "OLDAP-2.2.1"
+  ],
+  "Open LDAP Public License v2.3": [
+    "OLDAP-2.3"
+  ],
+  "Open LDAP Public License v2.4": [
+    "OLDAP-2.4"
+  ],
+  "Open LDAP Public License v2.5": [
+    "OLDAP-2.5"
+  ],
+  "Open LDAP Public License v2.6": [
+    "OLDAP-2.6"
+  ],
+  "Open LDAP Public License v2.7": [
+    "OLDAP-2.7"
+  ],
+  "Open LDAP Public License v2.8": [
+    "OLDAP-2.8"
+  ],
+  "Open Market License": [
+    "OML"
+  ],
+  "Open Public License v1.0": [
+    "OPL-1.0"
+  ],
+  "Open Software License 1.0": [
+    "OSL-1.0"
+  ],
+  "Open Software License 1.1": [
+    "OSL-1.1"
+  ],
+  "Open Software License 2.0": [
+    "OSL-2.0"
+  ],
+  "Open Software License 2.1": [
+    "OSL-2.1"
+  ],
+  "Open Software License 3.0": [
+    "OSL-3.0"
+  ],
+  "OpenSSL License": [
+    "OpenSSL"
+  ],
+  "PHP License v3.0": [
+    "PHP-3.0"
+  ],
+  "PHP License v3.01": [
+    "PHP-3.01"
+  ],
+  "Plexus Classworlds License": [
+    "Plexus"
+  ],
+  "PostgreSQL License": [
+    "PostgreSQL"
+  ],
+  "Python License 2.0": [
+    "Python-2.0"
+  ],
+  "Q Public License 1.0": [
+    "QPL-1.0"
+  ],
+  "Qhull License": [
+    "Qhull"
+  ],
+  "RSA Message-Digest License": [
+    "RSA-MD"
+  ],
+  "Rdisc License": [
+    "Rdisc"
+  ],
+  "RealNetworks Public Source License v1.0": [
+    "RealNetworks Public Source License V1.0",
+    "RPSL-1.0"
+  ],
+  "Reciprocal Public License 1.1": [
+    "RPL-1.1"
+  ],
+  "Reciprocal Public License 1.5": [
+    "RPL-1.5"
+  ],
+  "Red Hat eCos Public License v1.1": [
+    "RHeCos-1.1"
+  ],
+  "Ricoh Source Code Public License": [
+    "RSCPL"
+  ],
+  "Ruby License": [
+    "Ruby"
+  ],
+  "SCEA Shared Source License": [
+    "SCEA"
+  ],
+  "SGI Free Software License B v1.0": [
+    "SGI-B-1.0"
+  ],
+  "SGI Free Software License B v1.1": [
+    "SGI-B-1.1"
+  ],
+  "SGI Free Software License B v2.0": [
+    "SGI-B-2.0",
+    "SGI Free Software License B 2.0"
+  ],
+  "SIL Open Font License 1.0": [
+    "OFL-1.0"
+  ],
+  "SIL Open Font License 1.1": [
+    "OFL-1.1"
+  ],
+  "SNIA Public License 1.1": [
+    "SNIA"
+  ],
+  "Sax Public Domain Notice": [
+    "SAX-PD"
+  ],
+  "Saxpath License": [
+    "Saxpath"
+  ],
+  "Scheme Widget Library (SWL) Software License Agreement": [
+    "SWL"
+  ],
+  "Secure Messaging Protocol Public License": [
+    "SMPPL"
+  ],
+  "Sendmail License": [
+    "Sendmail"
+  ],
+  "Simple Public License 2.0": [
+    "SimPL-2.0"
+  ],
+  "Sleepycat License": [
+    "Sleepycat Software Product License",
+    "Sleepycat"
+  ],
+  "Spencer License 86": [
+    "Spencer-86"
+  ],
+  "Spencer License 94": [
+    "Spencer-94"
+  ],
+  "Spencer License 99": [
+    "Spencer-99"
+  ],
+  "Standard ML of New Jersey License": [
+    "SMLNJ"
+  ],
+  "SugarCRM Public License v1.1.3": [
+    "SugarCRM-1.1.3"
+  ],
+  "Sun Industry Standards Source License v1.1": [
+    "SISSL"
+  ],
+  "Sun Industry Standards Source License v1.2": [
+    "SISSL-1.2"
+  ],
+  "Sun Public License v1.0": [
+    "SPL-1.0"
+  ],
+  "Sybase Open Watcom Public License 1.0": [
+    "Watcom-1.0"
+  ],
+  "TCL/TK License": [
+    "TCL"
+  ],
+  "TCP Wrappers License": [
+    "TCP-wrappers"
+  ],
+  "TMate Open Source License": [
+    "TMate"
+  ],
+  "TORQUE v2.5+ Software License v1.1": [
+    "TORQUE-1.1"
+  ],
+  "The Unlicense": [
+    "Unlicense"
+  ],
+  "Trusster Open Source License": [
+    "TOSL"
+  ],
+  "Unicode License Agreement - Data Files and Software (2015)": [
+    "Unicode-DFS-2015"
+  ],
+  "Unicode License Agreement - Data Files and Software (2016)": [
+    "Unicode-DFS-2016"
+  ],
+  "Unicode Terms of Use": [
+    "Unicode-TOU"
+  ],
+  "Universal Permissive License v1.0": [
+    "UPL-1.0"
+  ],
+  "University of Illinois/NCSA Open Source License": [
+    "NCSA"
+  ],
+  "VOSTROM Public License for Open Source": [
+    "VOSTROM"
+  ],
+  "Vim License": [
+    "Vim"
+  ],
+  "Vovida Software License v1.0": [
+    "Vovida Software License v. 1.0",
+    "VSL-1.0"
+  ],
+  "W3C Documentation License": [
+    "W3C Document License"
+  ],
+  "W3C Software Notice and Document License (2015-05-13)": [
+    "W3C-20150513"
+  ],
+  "W3C Software Notice and License (1998-07-20)": [
+    "W3C-19980720"
+  ],
+  "W3C Software Notice and License (2002-12-31)": [
+    "W3C",
+    "W3C Software Notice and Document License (2002-12-31)"
+  ],
+  "Wsuipa License": [
+    "Wsuipa"
+  ],
+  "X.Net License": [
+    "Xnet"
+  ],
+  "X11 License": [
+    "X11"
+  ],
+  "XFree86 License 1.1": [
+    "XFree86-1.1"
+  ],
+  "XPP License": [
+    "xpp"
+  ],
+  "XSkat License": [
+    "XSkat"
+  ],
+  "Xerox License": [
+    "Xerox"
+  ],
+  "Yahoo! Public License v1.0": [
+    "Yahoo Public License 1.0",
+    "YPL-1.0"
+  ],
+  "Yahoo! Public License v1.1": [
+    "Yahoo Public License v 1.1",
+    "YPL-1.1"
+  ],
+  "Zed License": [
+    "Zed"
+  ],
+  "Zend License v2.0": [
+    "Zend-2.0"
+  ],
+  "Zimbra Public License v1.3": [
+    "Zimbra-1.3",
+    "Zimbra Public License 1.3"
+  ],
+  "Zimbra Public License v1.4": [
+    "Zimbra-1.4"
+  ],
+  "Zope Public License 1.1": [
+    "ZPL-1.1"
+  ],
+  "Zope Public License 2.0": [
+    "Zope Public License v 2.0",
+    "ZPL-2.0"
+  ],
+  "Zope Public License 2.1": [
+    "Zope Public License v 2.1",
+    "ZPL-2.1"
+  ],
+  "bzip2 and libbzip2 License v1.0.5": [
+    "bzip2-1.0.5"
+  ],
+  "bzip2 and libbzip2 License v1.0.6": [
+    "bzip2-1.0.6"
+  ],
+  "curl License": [
+    "curl"
+  ],
+  "diffmark license": [
+    "diffmark"
+  ],
+  "dvipdfm License": [
+    "dvipdfm"
+  ],
+  "eCos license version 2.0": [
+    "eCos-2.0",
+    "eCos License v2.0"
+  ],
+  "eGenix.com Public License 1.1.0": [
+    "eGenix"
+  ],
+  "enna License": [
+    "MIT-enna"
+  ],
+  "feh License": [
+    "MIT-feh"
+  ],
+  "gSOAP Public License v1.3b": [
+    "gSOAP-1.3b"
+  ],
+  "gnuplot License": [
+    "gnuplot"
+  ],
+  "iMatix Standard Function Library Agreement": [
+    "iMatix"
+  ],
+  "libpng License": [
+    "Libpng"
+  ],
+  "libtiff License": [
+    "libtiff"
+  ],
+  "mpich2 License": [
+    "mpich2"
+  ],
+  "psfrag License": [
+    "psfrag"
+  ],
+  "psutils License": [
+    "psutils"
+  ],
+  "wxWindows Library License": [
+    "WXwindows"
+  ],
+  "xinetd License": [
+    "xinetd"
+  ],
+  "zlib License": [
+    "Zlib"
+  ],
+  "zlib/libpng License with Acknowledgement": [
+    "zlib-acknowledgement"
+  ]
+}

--- a/lib/unifiedlist.js
+++ b/lib/unifiedlist.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const unifiedList = require('./resources/default-unifiedlist.json');
+
 // checks the licenses found against properties of approved list
 // to verify if the license name is found.
 function findApproved (approvedList, licensesFound) {
@@ -77,7 +79,6 @@ function check (xmlObject) {
   // gets the approved and not approved licenses from the default unified list.
   const approvedList = [];
   const notApprovedList = [];
-  const unifiedList = require('./resources/default-unifiedlist.json');
   Object.keys(unifiedList).forEach(key => {
     if (unifiedList[key].approved === 'yes') {
       approvedList.push(unifiedList[key]);
@@ -92,8 +93,19 @@ function check (xmlObject) {
   printNotApproved(notApprovedFound);
 }
 
+function urlForName (name) {
+  if (name === 'UNKNOWN') {
+    return name;
+  }
+  if (unifiedList[name]) {
+    return unifiedList[name].url;
+  }
+  throw Error(`No URL was found for [${name}]`);
+}
+
 module.exports = {
   check: check,
+  urlForName: urlForName,
   _getLicensesFromXmlObject: getLicensesFromXmlObject,
   _findApproved: findApproved,
   _findNotApproved: findNotApproved,

--- a/test/canonical-name-test.js
+++ b/test/canonical-name-test.js
@@ -11,8 +11,8 @@ test('Should map license names to one defined in map file', (t) => {
   t.equal(mapper.map('The MIT License'), 'MIT License', 'should map');
   t.equal(mapper.map('MIT'), 'MIT License', 'should map');
   t.equal(mapper.map('Something'), 'Some', 'should map');
-  t.equal(mapper.map('Bogus'), 'Bogus', 'unmapped should just pass through');
-  t.equal(mapper.map('MIT, AST'), 'MIT License, AST', 'should map comma separated');
+  t.equal(mapper.map('Bogus'), 'UNKNOWN', 'unmapped should just pass through');
+  t.equal(mapper.map('MIT, AST'), 'MIT License, UNKNOWN', 'should map comma separated');
   t.end();
 });
 

--- a/test/unifiedlist-test.js
+++ b/test/unifiedlist-test.js
@@ -122,3 +122,14 @@ test('Should print approved and approved licenses', (t) => {
   t.deepEqual(log, expected);
   t.end();
 });
+
+test('Should return url for the specified license name', (t) => {
+  t.plan(4);
+  t.equal(unifiedlist.urlForName('3dfx Glide License'),
+      'http://www.users.on.net/~triforce/glidexp/COPYING.txt');
+  t.equal(unifiedlist.urlForName('4Suite Copyright License'), '');
+  t.equal(unifiedlist.urlForName('UNKNOWN'), 'UNKNOWN');
+  t.throws(() => { unifiedlist.urlForName('bogus'); },
+      'No URL was found for [bogus]');
+  t.end();
+});


### PR DESCRIPTION
Instead of using the absolute file url to the license file this commit
uses the url specified in the unifiedlist.json.

This commit also adds a default canonical names mapping file so that one
is not required to be specified on the command line. This is just a
default and can be overridden using the --namemap options as the command
line.

Closes: #110