### PR TITLE
src: support array of names for urlForName

### DIFF
--- a/lib/unifiedlist.js
+++ b/lib/unifiedlist.js
@@ -94,6 +94,15 @@ function check (xmlObject) {
 }
 
 function urlForName (name) {
+  if (name.indexOf(',') !== -1) {
+    return name.split(',').map((name) => {
+      return _urlForName(name.trim());
+    }).join(', ');
+  }
+  return _urlForName(name);
+}
+
+function _urlForName (name) {
   if (name === 'UNKNOWN') {
     return name;
   }

--- a/test/unifiedlist-test.js
+++ b/test/unifiedlist-test.js
@@ -133,3 +133,10 @@ test('Should return url for the specified license name', (t) => {
       'No URL was found for [bogus]');
   t.end();
 });
+
+test('urlForName should be able to handle comma separated names', (t) => {
+  t.plan(1);
+  t.equal(unifiedlist.urlForName('3dfx Glide License, UNKNOWN'),
+      'http://www.users.on.net/~triforce/glidexp/COPYING.txt, UNKNOWN');
+  t.end();
+});


### PR DESCRIPTION
There is currently a bug when trying to map a license name to a url does
not accept a comma separated list of names. This can happen when using a
deprecated license property in package.json.

This commit adds a check and reports any urls found.

Closes: #124