### PR TITLE
Use prepublishOnly instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
     "lint": "eslint test/*.js index.js lib/*.js bin/*.js",
     "docs": "./node_modules/.bin/jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./lib/*.js",
-    "prepublish": "nsp check",
+    "prepublishOnly": "nsp check",
     "release": "standard-version"
   },
   "files": [


### PR DESCRIPTION
See https://docs.npmjs.com/misc/scripts#prepublish-and-prepare for a
detailed explanation.

Without this change, if there are any vulnerabilities found by `nsp
check`, then users can't install this module, without using
`--ignore-scripts`.