### PR TITLE
fixed problem with licenses directory to avoid collisions

### DIFF
--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -45,7 +45,7 @@ function createHtml (options, xmlObject, dependencyLicenseFiles) {
     const dependencyFound = findDependency(d.packageName);
     if (dependencyFound) {
       const finalName = `${dependencyFound.name}_${dependencyFound.type}.txt`;
-      const link = path.join('./license', finalName);
+      const link = path.join('./licenses', finalName);
       d.localLicense = require('querystring').escape(link);
       d.linkLabel = link;
     } else {
@@ -95,7 +95,7 @@ function mergeXmls (options) {
 // Creates a license directory if not exists.
 // This function is executed when using --html option.
 function createLicenseDir () {
-  const dir = path.join(process.cwd(), 'license');
+  const dir = path.join(process.cwd(), 'licenses');
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
@@ -103,7 +103,7 @@ function createLicenseDir () {
 
 // Copy license files to 'license' directory.
 function copyLicenseFiles (dependencyLicenseFiles) {
-  const dir = path.join(process.cwd(), 'license');
+  const dir = path.join(process.cwd(), 'licenses');
   dependencyLicenseFiles.forEach(d => {
     const finalName = `${d.name}_${d.type}.txt`;
     fs.createReadStream(d.file)


### PR DESCRIPTION
Changed the output directory to be licenses to avoid a collision with the common term LICENSE which appears in a lot of projects. 