### PR TITLE
bug: fix ENFILE: file table overflow by using graceful-fs module

### DIFF
--- a/lib/file-reader.js
+++ b/lib/file-reader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('graceful-fs');
 var request = require('sync-request');
 
 /**

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -3,7 +3,7 @@
 const js2xmlparser = require('js2xmlparser');
 const xml = require('../lib/xml.js');
 const html = require('../lib/html.js');
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const yaml = require('yamljs');
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "bucharest-gold/license-reporter"
   },
   "dependencies": {
+    "graceful-fs": "^4.1.11",
     "js2xmlparser": "^3.0.0",
     "jsonschema": "^1.2.0",
     "license-checker": "^13.1.0",


### PR DESCRIPTION
Connects to #202 
I can't reproduce this on fedora. Seems to be a MacOS issue.