### PR TITLE
fix: check if  nyc arguments affects the coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "License-reporter gathers license information and reports them in various formats.",
   "main": "index.js",
   "scripts": {
-    "test": "nyc --check-coverage --lines 90 tape test/*.js | tap-diff",
+    "test": "nyc tape test/*.js | tap-diff",
     "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
     "lint": "eslint test/*.js index.js lib/*.js bin/*.js",
     "docs": "./node_modules/.bin/jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./lib/*.js",


### PR DESCRIPTION
Seems that  --check-coverage --lines
args are affecting the coverage report.

This PR is to check if this is true.