### PR TITLE
🐛 Handle names as array in report module

### DIFF
--- a/lib/modules/report.mdl.js
+++ b/lib/modules/report.mdl.js
@@ -19,7 +19,11 @@ const reportFileName = (name, type) => {
 
 const reportFileData = (projectMetaData) => {
   projectMetaData.dependencies.dependency.forEach(d => {
-    if (d.file && d.file.includes(d.licenses.license[0].name.split(' ')[0].toUpperCase())) {
+    const nameUpperCase = typeof d.licenses.license[0].name === 'string'
+          ? d.licenses.license[0].name.split(' ')[0].toUpperCase()
+          : d.licenses.license[0].name[0];
+
+    if (d.file && d.file.includes(nameUpperCase)) {
       const link = join('./', d.file);
       d.localLicense = require('querystring').escape(link).replace(/%2F/gi, '/');
       d.linkLabel = link;


### PR DESCRIPTION
In the `projectMetaData` that the report command hands to the report
module, it's possible that the `licenses.license.name` field is an
array, such as for `rc@0.4.0`:

```json
"dependencies": {
  "dependency": [
    {
      "packageName": "rc",
      "version": "0.4.0",
      "licenses": {
        "license": [
          {
            "name": [
              "BSD",
              "MIT",
              "Apache2"
            ],
            "url": "UNKNOWN"
          }
        ]
      },
      "file": "RC_BSD,MIT,APACHE2.TXT"
    }
  ]
}
```

In this case, there won't be a `.split` function on it.

I'm not sure if this is the best way to do this or not.