### PR TITLE
🎨 Minor suggestions for file names and html output

### DIFF
--- a/lib/modules/report.mdl.js
+++ b/lib/modules/report.mdl.js
@@ -37,7 +37,7 @@ const reportFileData = (projectMetaData) => {
 
 const htmlReport = (reportData) => {
   html.parse(reportData).then(output => {
-    fs.writeFileSync(join(ldir, 'license.html'), output);
+    fs.writeFileSync(join(ldir, 'licenses.html'), output);
   });
 };
 

--- a/lib/modules/resources/template.html
+++ b/lib/modules/resources/template.html
@@ -15,8 +15,8 @@
 </tr>
 {{#dependencies.dependency}}
 <tr>
-<td>{{packageName}}</td>
 <td>N/A</td>
+<td>{{packageName}}</td>
 <td>{{version}}</td>
 <td>{{#licenses.license}}{{url}}{{/licenses.license}}</td>
 <td><a href={{#licenses.license}}{{localLicense}}{{/licenses.license}}>{{#licenses.license}}{{linkLabel}}{{/licenses.license}}</a></td>

--- a/test/lib/html-test.js
+++ b/test/lib/html-test.js
@@ -49,15 +49,15 @@ test('Should generate html from xml', (t) => {
 <th>Local Licenses</th>
 </tr>
 <tr>
-<td>node-builtins</td>
 <td>N/A</td>
+<td>node-builtins</td>
 <td>0.1.1</td>
 <td>Foo</td>
 <td><a href=></a></td>
 </tr>
 <tr>
-<td>roi</td>
 <td>N/A</td>
+<td>roi</td>
 <td>0.15.0</td>
 <td>UNKNOWN</td>
 <td><a href=></a></td>


### PR DESCRIPTION
These are 2 things that I figured a PR was an easier way to
propose/discuss, rather than creating an issue to get your feeling
about them. Below are the commit messages:

```
🎨 Call it licenses.html instead of license.html

The xml and css (maybe others?) use the plural 'licenses.<extension>' in
their file names. This just changes the html file to match those.
```
and

```
🎨 Put packageName in "Package Artifact" col in html

Before this change, it would be in the "Package Group" column. I guess the
2 columns would map to a groupId and artifactId in maven. Given that we
don't have groupIds in npm dependencies, I think the name fits better in
the artifact column.
```

Let me know what you think!