### PR TITLE
💥 Only include dev deps if option set

### DIFF
--- a/lib/commands/console.cmd.js
+++ b/lib/commands/console.cmd.js
@@ -35,6 +35,11 @@ module.exports = () => {
       alias: 'fdt',
       describe: 'Will list all production licenses for all modules.',
       default: false
+    },
+    'include-dev-dependencies': {
+      alias: 'idd',
+      describe: 'Will include devDependencies in output',
+      default: false
     }
   };
 
@@ -62,7 +67,7 @@ module.exports = () => {
         process.exit(1);
       }
 
-      checker.check(argv.cwd)
+      checker.check(argv.cwd, !argv.idd)
       .then((data) => {
         const projectMetaData = consoleModule.transform(data,
           canonicalNameMapper, argv.cwd, argv.ilc, argv.fdt);

--- a/lib/commands/report.cmd.js
+++ b/lib/commands/report.cmd.js
@@ -41,6 +41,11 @@ module.exports = () => {
       alias: 'fdt',
       describe: 'Will list all production licenses for all modules.',
       default: false
+    },
+    'include-dev-dependencies': {
+      alias: 'idd',
+      describe: 'Will include devDependencies in HTML report',
+      default: false
     }
   };
 
@@ -70,7 +75,7 @@ module.exports = () => {
 
       createLicenseDir();
 
-      checker.check(argv.cwd)
+      checker.check(argv.cwd, !argv.idd)
       .then((data) => {
         const projectMetaData = reportModule.transform(data,
           canonicalNameMapper, argv.cwd, argv.ilc, argv.fdt);

--- a/lib/commands/save.cmd.js
+++ b/lib/commands/save.cmd.js
@@ -38,6 +38,11 @@ module.exports = () => {
       describe: 'Will list all production licenses for all modules.',
       default: false
     },
+    'include-dev-dependencies': {
+      alias: 'idd',
+      describe: 'Will include devDependencies in output file',
+      default: false
+    },
     xml: {
       describe: 'Saves as XML.',
       type: 'string',
@@ -81,7 +86,7 @@ module.exports = () => {
 
       createLicenseDir();
 
-      checker.check(argv.cwd)
+      checker.check(argv.cwd, !argv.idd)
       .then((data) => {
         const projectMetaData = consoleModule.transform(data,
           canonicalNameMapper, argv.cwd, argv.ilc, argv.fdt);

--- a/lib/modules/checker.js
+++ b/lib/modules/checker.js
@@ -2,9 +2,9 @@
 
 const licenseChecker = require('license-checker');
 
-const check = (cwd) => {
+const check = (cwd, productionOnly) => {
   return new Promise((resolve, reject) => {
-    licenseChecker.init({start: cwd}, (error, json) => {
+    licenseChecker.init({start: cwd, production: productionOnly}, (error, json) => {
       if (error) {
         reject(error);
       } else {

--- a/test/lib/checker-test.js
+++ b/test/lib/checker-test.js
@@ -4,17 +4,36 @@ const test = require('blue-tape');
 const cwd = process.cwd();
 const checker = require('../../lib/modules/checker');
 
+const numNycDeps = json => json.filter(d => d.dependency.startsWith('nyc@')).length;
+
 test('Checks licenses.', (t) => {
-  t.plan(4);
+  t.plan(5);
   return checker.check(cwd)
   .then((json) => {
     t.ok(json, `The json has content.`);
     t.ok(json[0].hasOwnProperty('dependency'), `The json has dependency property.`);
     t.ok(json[0].hasOwnProperty('licenses'), `The json has licenses property.`);
     t.ok(json[0].hasOwnProperty('file'), `The json has file property.`);
+    t.ok(numNycDeps(json) > 0, `Contains devDependency 'nyc'`);
   })
   .catch((e) => {
     console.error(e);
     t.fail(e);
   });
+});
+
+test('Checks licenses with production-only argument.', (t) => {
+  t.plan(5);
+  return checker.check(cwd, true)
+    .then((json) => {
+      t.ok(json, `The json has content.`);
+      t.ok(json[0].hasOwnProperty('dependency'), `The json has dependency property.`);
+      t.ok(json[0].hasOwnProperty('licenses'), `The json has licenses property.`);
+      t.ok(json[0].hasOwnProperty('file'), `The json has file property.`);
+      t.ok(numNycDeps(json) === 0, `Doesn't contain devDependency 'nyc'`);
+    })
+    .catch((e) => {
+      console.error(e);
+      t.fail(e);
+    });
 });


### PR DESCRIPTION
This introduces an '--include-dev-dependencies' option to the console,
report, and save commands. The default behaviour changes here also to
include only production dependencies by default.

Fixes #241.